### PR TITLE
Add support for installing code sniffer standard with composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 ImboStandard-*.tgz
-/vendor/
+vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ImboStandard-*.tgz
+/vendor/

--- a/README.md
+++ b/README.md
@@ -5,17 +5,31 @@ This is the coding standard used with [PHP_CodeSniffer](http://pear.php.net/pack
 
 Installation
 ------------
-The coding standard is installed using `pear`:
+The coding standard is installed using either `pear` or `composer`:
 
+#### Pear
 ```
 sudo pear config-set auto_discover 1
 sudo pear install --alldeps pear.starzinger.net/ImboStandard
 ```
 
+#### Composer
+Add the following to you (dev-)dependencies;
+
+```
+"imbo/imbo-phpcs-standard": "dev-master"
+```
+
 Usage
 -----
-After installing `PHP_CodeSniffer` and `ImboStandard` you can check your code against the standard by running the following command:
+After installing `PHP_CodeSniffer` and `ImboStandard` with `Pear` you can check your code against the standard by running the following command:
 
 ```
 phpcs --standard=Imbo /path/to/your/code
+```
+
+Ïf you installed using composer you have to use the following command:
+
+```
+phpcs --standard=vendor/imbo/imbo-phpcs-standard/Imbo /path/to/your/code
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "imbo/imbo-phpcs-standard",
+    "description": "Imbo PHP Codesniffer standard",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Christer Edvartsen",
+            "email": "cogo@starzinger.net"
+        }
+    ],
+    "require": {}
+}


### PR DESCRIPTION
In order to ease the process of using the Imbo code standard in plugins and such, having the option of installing it with composer in the same way that's done with other dev tools would be nice.

I've added the composer.json and a note on how to install/use. I obviously needs to be published on Packagist as well, but given that this is your work, @christeredvartsen, you should probably be the one doing this (if it is to be done).
